### PR TITLE
authlib 1.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "authlib" %}
-{% set version = "1.0.1" %}
-{% set sha256 = "6e74a4846ac36dfc882b3cc2fbd3d9eb410a627f2f2dc11771276655345223b1" %}
+{% set version = "1.2.0" %}
+{% set sha256 = "4fa3e80883a5915ef9f5bc28630564bc4ed5b5af39812a3ff130ec76bd631e9d" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index e126b93..dc528b5 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "authlib" %}
-{% set version = "1.0.1" %}
-{% set sha256 = "6e74a4846ac36dfc882b3cc2fbd3d9eb410a627f2f2dc11771276655345223b1" %}
+{% set version = "1.2.0" %}
+{% set sha256 = "4fa3e80883a5915ef9f5bc28630564bc4ed5b5af39812a3ff130ec76bd631e9d" %}
 
 package:
   name: {{ name|lower }}

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/lepture/authlib/releases
[Diff between the latest and previous upstream releases](https://github.com/lepture/authlib/compare/1.0.1...1.2.0)
License: https://github.com/lepture/authlib/blob/master/LICENSE
Requirements:
 * setup.cfg:  https://github.com/lepture/authlib/blob/v1.2.0/setup.cfg
 * setup.py:  https://github.com/lepture/authlib/blob/v1.2.0/setup.py
 *  pyproject.toml:  https://github.com/lepture/authlib/blob/v1.2.0/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: medium | Category: other | subcategory:  | pkg_type: python
 * Outdated platforms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.2.0
 * Release on PyPi:
    * version: 1.2.0
    * date: 2022-12-06T08:40:08
* [PyPi history](https://pypi.org/project/authlib/#history)
 * Popularity: 
    * 3 months downloads: 17984.0
Key is not found. 0

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the 'build_number' is correct
3. - [x] has 'setuptools'
5. - [x] has 'wheel'
7. - [x] 'pip' in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is 'architecture specific'
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-3-Clause
    - [x] License is 'spdx' compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Other:**

<details>
Checking 'authlib' recipe...
~/Library/CloudStorage/OneDrive-SoftServe,Inc/src/aggregate/authlib-feedstock/recipe ~/Library/CloudStorage/OneDrive-SoftServe,Inc/src/finder
--- Build Requirements ---
>> Empty Host Section <<
--- Host Requirements ---
pip: main
setuptools: main
wheel: main
--- Run Requirements ---
requests: main
cryptography >=3.2: main
~/Library/CloudStorage/OneDrive-SoftServe,Inc/src/finder

</details>

<details>

https://repo.anaconda.com/pkgs/main/noarch
https://repo.anaconda.com/pkgs/main/linux-64
authlib-1.0.1-py310h06a4308_0.tar.bz2
authlib-1.0.1-py37h06a4308_0.tar.bz2
authlib-1.0.1-py38h06a4308_0.tar.bz2
authlib-1.0.1-py39h06a4308_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-ppc64le
authlib-1.0.1-py39h6ffa863_0.tar.bz2
authlib-1.0.1-py310h6ffa863_0.tar.bz2
authlib-1.0.1-py38h6ffa863_0.tar.bz2
authlib-1.0.1-py37h6ffa863_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-aarch64/
authlib-1.0.1-py310hd43f75c_0.tar.bz2
authlib-1.0.1-py38hd43f75c_0.tar.bz2
authlib-1.0.1-py39hd43f75c_0.tar.bz2
authlib-1.0.1-py37hd43f75c_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-s390x/
authlib-1.0.1-py37ha847dfd_0.tar.bz2
authlib-1.0.1-py310ha847dfd_0.tar.bz2
authlib-1.0.1-py39ha847dfd_0.tar.bz2
authlib-1.0.1-py38ha847dfd_0.tar.bz2
https://repo.anaconda.com/pkgs/main/osx-64
authlib-1.0.1-py310hecd8cb5_0.tar.bz2
authlib-1.0.1-py37hecd8cb5_0.tar.bz2
authlib-1.0.1-py39hecd8cb5_0.tar.bz2
authlib-1.0.1-py38hecd8cb5_0.tar.bz2
https://repo.anaconda.com/pkgs/main/osx-arm64/
authlib-1.0.1-py310hca03da5_0.tar.bz2
authlib-1.0.1-py38hca03da5_0.tar.bz2
authlib-1.0.1-py39hca03da5_0.tar.bz2
https://repo.anaconda.com/pkgs/main/win-64
authlib-1.0.1-py38haa95532_0.tar.bz2
authlib-1.0.1-py39haa95532_0.tar.bz2
authlib-1.0.1-py37haa95532_0.tar.bz2
authlib-1.0.1-py310haa95532_0.tar.bz2

</details>

<details>

                             name version                   spec
0  airflow-with-github_enterprise   2.4.3  authlib >=0.14,<1.0.0
1  airflow-with-github_enterprise   2.3.3  authlib >=0.14,<1.0.0
2        airflow-with-google_auth   2.4.3  authlib >=0.14,<1.0.0
3        airflow-with-google_auth   2.3.3  authlib >=0.14,<1.0.0
4               simple-salesforce  1.11.2                authlib
5               simple-salesforce  1.11.1                authlib
6               simple-salesforce  1.10.1                authlib

</details>

</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/authlib-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/authlib-feedstock/tree/1.2.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/authlib)
* [Diff between upstream and feature branch](https://github.com/conda-forge/authlib-feedstock/compare/main...AnacondaRecipes:1.2.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/authlib-feedstock/compare/master...AnacondaRecipes:1.2.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/authlib-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.2.0 git@github.com:AnacondaRecipes/authlib-feedstock.git
```
