### PR TITLE
authlib 1.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,8 @@ test:
     - pip
   commands:
     - pip check
-  downstreams:
-    - simple-salesforce 1.11.2
+  # downstreams:
+  #   - simple-salesforce 1.11.2
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
     The ultimate Python library in building OAuth and OpenID Connect servers.
     It is designed from low level specifications implementations to high level frameworks integrations,
     to meet the needs of everyone.
-  doc_url: https://docs.authlib.org/en/latest/
+  doc_url: https://docs.authlib.org/
   dev_url: https://github.com/lepture/authlib
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,17 @@
 {% set name = "authlib" %}
-{% set version = "1.0.1" %}
-{% set sha256 = "6e74a4846ac36dfc882b3cc2fbd3d9eb410a627f2f2dc11771276655345223b1" %}
+{% set version = "1.3.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|capitalize }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7ae843f03c06c5c0debd63c9db91f9fda64fa62a42a77419fa15fbb7e7a58917
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
@@ -22,6 +21,7 @@ requirements:
     - wheel
   run:
     - python
+    # Keep requests at runtime for backward compatibility
     - requests
     - cryptography >=3.2
 
@@ -32,9 +32,9 @@ test:
     - pip
   commands:
     - pip check
-  # downstreams:
-  #   - simple-salesforce
-  #   - airflow
+  downstreams:
+    - simple-salesforce 1.11.2
+
 
 about:
   home: https://authlib.org/
@@ -42,7 +42,10 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: The ultimate Python library in building OAuth and OpenID Connect servers. JWS,JWE,JWK,JWA,JWT included. https://authlib.org/
-
+  description: |
+    The ultimate Python library in building OAuth and OpenID Connect servers.
+    It is designed from low level specifications implementations to high level frameworks integrations,
+    to meet the needs of everyone.
   doc_url: https://docs.authlib.org/en/latest/
   dev_url: https://github.com/lepture/authlib
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5306](https://anaconda.atlassian.net/browse/PKG-5306) 
- [Upstream repository](https://github.com/lepture/authlib/tree/v1.3.1)
- Changelog: https://github.com/lepture/authlib/releases
- Requirements:
  - https://github.com/lepture/authlib/blob/v1.3.1/setup.py 
  - https://github.com/lepture/authlib/blob/v1.3.1/pyproject.toml
  - https://docs.authlib.org/en/latest/basic/install.html#pip-install-authlib

### Explanation of changes:

- Clean up the recipe by conda-linter
- Add `description`

### Notes:

- To address CVE-2024-37568 with a score of 7.5
- I've tested the downstream package `simple-salesforce` and it builds fine. There are no other downstream packages except `airflow` but it's already deprecated in the _main_ channel https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=authlib

[PKG-5306]: https://anaconda.atlassian.net/browse/PKG-5306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ