### PR TITLE
authlib 1.5.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     # Keep requests at runtime for backward compatibility
     - requests
     - cryptography >=3.2
+  run_constrained:
+    - pycryptodomex >=3.10,<4
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "authlib" %}
-{% set version = "1.3.1" %}
+{% set version = "1.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,9 +7,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7ae843f03c06c5c0debd63c9db91f9fda64fa62a42a77419fa15fbb7e7a58917
+  sha256: 5cbc85ecb0667312c1cdc2f9095680bb735883b123fb509fde1e65b1c5df972e
 
 build:
+  skip: true  # [py>39]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 


### PR DESCRIPTION
> ## ☆ authlib 1.5.1 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7169) 
[Upstream](https://github.com/lepture/authlib/tree/v1.5.1)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added `skip` to python versions less than 3.9
> * Python 3.13 support added.